### PR TITLE
Password to initiate withdraw

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sol linguist-language=Solidity
+*.vy linguist-language=Python

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 
 ## How it works
 
-1. Insuree pays in a ransom amount that only an address that he / she controls can withdraw (kidnapper). Insuree must memorize the private key of this address or have access to it when being kidnapped. Insuree also sets an address which is a multisig controlled by his / her friends
+1. Insuree deploys the contract with the hash of a password that only they know. Optional: Fund the contract.
 
-2. Insuree gets kidnapped. He / she gives the kidnapper access to the private key being labelled `kidnapper`. Kidnapper can now call the `initiateRansomWithdraw` function, which activates an e.g. 3 day timer. After the 3 days have passed the kidnappers can withdraw the ransom
+2. Insuree gets kidnapped. Kidnapper makes a ransom demand. Anyone can top-off the insurance contract to hold at least enough funds to cover the ransom.
 
-3. Within the 3 day period, the friends of the kidnapped person can veto the ransom payment by calling `vetoWithdraw`. However, this function is very costly to call. For example, if the ransom that was paid in by the kidnapped insuree is 1k ETH, then the veto would cost the friends 2k ETH to cast. This 2k veto payment will be burned alongside the original e.g. 1k ransom payment.
+3. Insuree gives the password to the kidnapper. The kidnapper generates a hash of the password and his address (off-chain or with `generateHash`) and can now call `initiateRansomWithdraw(hash, ransomAmount)`. This activates a hardcoded timer (e.g. 3 days), after which the kidnapper can withdraw the ransom.
+
+4. During the delay period, the friends of the insuree can veto the ransom payment by calling `vetoWithdraw`. Calling this functions requires a payment of two times the ransom, and it will irreversibly burn the ransom and the payed amount. 
 
 ## Good case, kidnappers release insuree:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 2. Insuree gets kidnapped. Kidnapper makes a ransom demand. Anyone can top-off the insurance contract to hold at least enough funds to cover the ransom.
 
-3. Insuree gives the password to the kidnapper. The kidnapper generates a hash of the password and his address (off-chain or with `generateHash`) and can now call `initiateRansomWithdraw(hash, ransomAmount)`. This activates a hardcoded timer (e.g. 3 days), after which the kidnapper can withdraw the ransom.
+3. Insuree gives the password to the kidnapper. The kidnapper generates a hash of the password and his address (off-chain or with `generateHash`) and commits the hash to the contract with `commit`. After 20 blocks, the kidnapper can call `initiateRansomWithdraw(password, ransomAmount)`. This activates a hardcoded timer (e.g. 3 days), after which the kidnapper can withdraw the ransom.
 
 4. During the delay period, the friends of the insuree can veto the ransom payment by calling `vetoWithdraw`. Calling this functions requires a payment of two times the ransom, and it will irreversibly burn the ransom and the payed amount. 
 

--- a/contracts/KidnapInsurance.sol
+++ b/contracts/KidnapInsurance.sol
@@ -3,79 +3,89 @@ pragma solidity ^0.8.0;
 
 contract KidnapInsurance {
 
-    event Abducted();
+    event Abducted(address indexed kidnapper, uint256 requestedRansom);
     event Rescued();
     event FuckYou();
 
-    address public kidnapper;
-    address public friends;
-    address payable public ransomReceiver;
+    address payable public kidnapper;
+    address payable public friends;
+    uint256 public ransomAmount;
 
     uint256 public kidnappedTime;
-    bool public vetoed;
+    uint256 constant delay = 3 days;
 
-    uint256 constant ransom = 1000e18; // 1k ETH
-    uint256 constant veto = 2000e18; // 2k ETH
-    uint256 constant delay = 3 days; // 3 days
-
-    modifier onlyKidnapper() {
-        require(msg.sender == kidnapper, "Kidnapper: only kidnapper");
-        _;
-    }
-
-    modifier onlyFriends() {
-        require(msg.sender == friends, "Kidnapper: only friends");
-        _;
-    }
-
-    constructor(address _kidnapper, address _friends) payable {
-        require(msg.value == ransom, "Kidnapper: Deposit must be ransom");
-        kidnapper = _kidnapper;
+    constructor(address payable _friends) payable {
         friends = _friends;
     }
 
-    // Kidnapper Funcs
-    function initiateRansomWithdraw(address payable _receiver) onlyKidnapper public {
-        // Must be first kidnapp
-        require(kidnappedTime == 0, "Kidnapper: Already kindapped");
+    // Hash of the password to initiate ransom withdraw
+    bytes32 constant WITHDRAW_HASH = 0x81387e6fe7c09e310810396aee0057e20224fd16320359fae10f45392cba8c80;
 
-        // Not vetoed yet
-        require(!vetoed, "Kidnapper: Was vetoed");
+    // Generate a hash to show the sender knows the password. Can also be done off-chain.
+    function generateHash(string memory _password) public view returns (bytes32 hash) {
+        bytes32 passwordHash = keccak256(abi.encodePacked(_password));
+        hash = keccak256(abi.encodePacked(msg.sender, passwordHash));
+    }
+
+    function initiateRansomWithdraw(bytes32 _hash, uint256 _ransomAmount) public {
+        require(kidnapper == address(0), "Kidnapper: Already kindapped");
+        require(address(this).balance >= _ransomAmount, "Kidnapper: Not enough ransom available");
+
+        // Check if the kidnapper knows the password, front running proof
+        bytes32 correctHash = keccak256(abi.encodePacked(msg.sender, WITHDRAW_HASH));
+        require(correctHash == _hash, "Kidnapper: Invalid password or sender");
+
+        // Set kidnapper/withdraw address and amount
+        kidnapper = payable(msg.sender);
+        ransomAmount = _ransomAmount;
 
         // Set date when person was kidnapped
         kidnappedTime = block.timestamp;
 
-        // Set receiver of ransom to avoid withdraw front running
-        ransomReceiver = _receiver;
-
-        emit Abducted();
+        emit Abducted(kidnapper, _ransomAmount);
     }
 
     function withdrawRansom() public {
-        // Victim was rescued
-        require(!vetoed, "Kidnapper: Was vetoed");
-
         // Delay passed
         require(kidnappedTime + delay <= block.timestamp, "Kidnapper: Cannot withdraw yet");
 
+        // Ransom is available
+        require(address(this).balance >= ransomAmount, "Kidnapper: Was vetoed");
+
         // Pay Kidnappers
-        ransomReceiver.call{value: ransom}("");
+        kidnapper.call{value: ransomAmount}("");
+
+        // Return any remaining funds to friends
+        friends.call{value: address(this).balance}("");
 
         emit Rescued();
     }
 
-    // Friends Funcs
-    function vetoWithdraw() onlyFriends public payable {
-        // Friends must pay veto amount
-        require(msg.value == veto, "Kindapper: Insufficient veto amount");
-        require(address(this).balance >= veto + ransom, "Kindapper: Ransom already withdrawn");
+    function vetoWithdraw() public payable {
 
-        // Burn Veto + Ransom Amount
-        address(0).call{value: veto + ransom}("");
+        // Can only be called by trusted friend account
+        require(msg.sender == friends, "Kidnapper: only friends");
 
-        // Kindapper cannot withdraw funds
-        vetoed = true;
+        // Can only be done with an active ransom
+        require(
+            ransomAmount > 0 && address(this).balance - msg.value >= ransomAmount,
+            "Kidnapper: No active ransom"
+        );
+
+        // Friends must pay veto amount equal to two times the ransom
+        require(msg.value >= 2 * ransomAmount, "Kindapper: Insufficient veto amount");
+
+        // Burn Veto + Ransom Amount, return rest to friends
+        address(0).call{value: ransomAmount * 3}("");
+        friends.call{value: address(this).balance}("");
 
         emit FuckYou();
     }
+
+    receive() external payable {
+        // Once the ransom amount has been set, no more funds can be deposited
+        // To reset, deploy a new contract
+        require(kidnapper == address(0), "Kidnapper: Can't deposit any more funds");
+    }
+
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+import pytest
+
+
+@pytest.fixture(scope="function", autouse=True)
+def isolate(fn_isolation):
+    # perform a chain rewind after completing each test, to ensure proper isolation
+    # https://eth-brownie.readthedocs.io/en/v1.12.3/tests-pytest-intro.html#isolation-fixtures
+    pass
+
+
+@pytest.fixture(scope="module")
+def frontrunner(accounts):
+    return accounts[4]
+
+
+@pytest.fixture(scope="module")
+def kidnapper(accounts):
+    return accounts[3]
+
+
+@pytest.fixture(scope="module")
+def friends(accounts):
+    return accounts[2]
+
+
+@pytest.fixture(scope="module")
+def victim(accounts):
+    return accounts[1]
+
+
+@pytest.fixture(scope="module")
+def insurance(KidnapInsurance, victim, friends):
+    return KidnapInsurance.deploy(friends, {'from': victim, 'value': "10 ether"})
+
+
+@pytest.fixture(scope="module")
+def password():
+    return "s3cr3tphras3"
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,3 +37,14 @@ def insurance(KidnapInsurance, victim, friends):
 def password():
     return "s3cr3tphras3"
 
+
+@pytest.fixture(scope="module")
+def committed_insurance(insurance, kidnapper, password, chain):
+    commit_hash = insurance.generateHash(password, {'from': kidnapper})
+    insurance.commit(commit_hash, {'from': kidnapper})
+    chain.mine(25)
+    return insurance
+
+
+
+

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -1,0 +1,37 @@
+from brownie import reverts
+
+
+def test_commit(insurance, kidnapper, password):
+    commit_hash = insurance.generateHash(password, {'from': kidnapper})
+    tx = insurance.commit(commit_hash, {'from': kidnapper})
+    assert insurance.commitHash(kidnapper) == commit_hash
+    assert insurance.commitBlock(kidnapper) == tx.block_number
+
+
+def test_ransom_succeeds(insurance, chain, kidnapper, password):
+    commit_hash = insurance.generateHash(password, {'from': kidnapper})
+    insurance.commit(commit_hash, {'from': kidnapper})
+    chain.mine(25)
+    tx = insurance.initiateRansomWithdraw(password, "1 ether", {'from': kidnapper})
+    assert "Abducted" in tx.events
+
+
+def test_no_commit(insurance, kidnapper, password):
+    with reverts("Kidnapper: Commit hash first"):
+        insurance.initiateRansomWithdraw(password, "1 ether", {'from': kidnapper})
+
+
+def test_wrong_password(insurance, chain, kidnapper):
+    password = "wrong password"
+    commit_hash = insurance.generateHash(password, {'from': kidnapper})
+    insurance.commit(commit_hash, {'from': kidnapper})
+    chain.mine(25)
+    with reverts("Kidnapper: Invalid password or sender"):
+        insurance.initiateRansomWithdraw(password, "1 ether", {'from': kidnapper})
+
+
+def test_no_frontrunning(insurance, frontrunner, password):
+    commit_hash = insurance.generateHash(password, {'from': frontrunner})
+    insurance.commit(commit_hash, {'from': frontrunner})
+    with reverts("Kidnapper: No front running"):
+        insurance.initiateRansomWithdraw(password, "1 ether", {'from': frontrunner})

--- a/tests/test_kidnap.py
+++ b/tests/test_kidnap.py
@@ -1,114 +1,97 @@
 from brownie import Wei, reverts
 
 
-def test_rescued(insurance, chain, kidnapper, password):
+def test_rescued(committed_insurance, chain, kidnapper, password):
     ransom = Wei("10 ether")
     initial_kidnapper = kidnapper.balance()
-    password_hash = insurance.generateHash(password, {'from': kidnapper})
-    insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
+    committed_insurance.initiateRansomWithdraw(password, ransom, {'from': kidnapper})
     chain.sleep(60 * 60 * 24 * 3 + 1000)  # 3 days and 1000 seconds
-    insurance.withdrawRansom({'from': kidnapper})
+    committed_insurance.withdrawRansom({'from': kidnapper})
     assert initial_kidnapper + ransom == kidnapper.balance()
 
 
-def test_abducted_rescued(insurance, chain, kidnapper, password):
+def test_abducted_rescued(committed_insurance, chain, kidnapper, password):
     ransom = Wei("10 ether")
-    password_hash = insurance.generateHash(password, {'from': kidnapper})
-    tx = insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
+    tx = committed_insurance.initiateRansomWithdraw(password, ransom, {'from': kidnapper})
     assert "Abducted" in tx.events
     assert tx.events["Abducted"].values() == [kidnapper, ransom]
 
     chain.sleep(60 * 60 * 24 * 3 + 1000)  # 3 days and 1000 seconds
-    tx = insurance.withdrawRansom({'from': kidnapper})
+    tx = committed_insurance.withdrawRansom({'from': kidnapper})
     assert "Rescued" in tx.events
 
 
-def test_ransom_too_high(insurance, kidnapper, password):
+def test_ransom_too_high(committed_insurance, kidnapper, password):
     ransom = Wei("100 ether")
-    password_hash = insurance.generateHash(password, {'from': kidnapper})
     with reverts("Kidnapper: Not enough ransom available"):
-        insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
+        committed_insurance.initiateRansomWithdraw(password, ransom, {'from': kidnapper})
 
 
-def test_friends_increase_deposit(insurance, kidnapper, password, friends):
+def test_friends_increase_deposit(committed_insurance, kidnapper, password, friends):
     ransom = Wei("100 ether")
-    friends.transfer(insurance, "90 ether")
-    password_hash = insurance.generateHash(password, {'from': kidnapper})
-    insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
-    assert insurance.ransomAmount() == ransom
+    friends.transfer(committed_insurance, "90 ether")
+    committed_insurance.initiateRansomWithdraw(password, ransom, {'from': kidnapper})
+    assert committed_insurance.ransomAmount() == ransom
 
 
-def test_wrong_password(insurance, kidnapper):
-    password_hash = insurance.generateHash("wrong password", {'from': kidnapper})
+def test_wrong_password(committed_insurance, kidnapper):
     with reverts("Kidnapper: Invalid password or sender"):
-        insurance.initiateRansomWithdraw(password_hash, "1 ether", {'from': kidnapper})
+        committed_insurance.initiateRansomWithdraw("wrong password", "1 ether", {'from': kidnapper})
 
 
-def test_frontrunning_protection(insurance, kidnapper, frontrunner, password):
-    password_hash = insurance.generateHash(password, {'from': kidnapper})
-    with reverts("Kidnapper: Invalid password or sender"):
-        insurance.initiateRansomWithdraw(password_hash, "1 ether", {'from': frontrunner})
-
-
-def test_no_early_withdraw(insurance, kidnapper, password):
-    password_hash = insurance.generateHash(password, {'from': kidnapper})
-    insurance.initiateRansomWithdraw(password_hash, "10 ether", {'from': kidnapper})
+def test_no_early_withdraw(committed_insurance, kidnapper, password):
+    committed_insurance.initiateRansomWithdraw(password, "10 ether", {'from': kidnapper})
     with reverts("Kidnapper: Cannot withdraw yet"):
-        insurance.withdrawRansom({'from': kidnapper})
+        committed_insurance.withdrawRansom({'from': kidnapper})
 
 
-def test_return_excess_funds(insurance, chain, kidnapper, friends, password):
-    friends.transfer(insurance, "90 ether")  # total 100 ether on insurance
+def test_return_excess_funds(committed_insurance, chain, kidnapper, friends, password):
+    friends.transfer(committed_insurance, "90 ether")  # total 100 ether on insurance
     ransom = Wei("50 ether")
     initial_friends = friends.balance()
-    password_hash = insurance.generateHash(password, {'from': kidnapper})
-    insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
+    committed_insurance.initiateRansomWithdraw(password, ransom, {'from': kidnapper})
     chain.sleep(60 * 60 * 24 * 3 + 1000)  # 3 days and 1000 seconds
-    insurance.withdrawRansom({'from': kidnapper})
+    committed_insurance.withdrawRansom({'from': kidnapper})
     # 50 eth to kidnapper and friends each
     assert initial_friends + Wei("50 ether") == friends.balance()
 
 
-def test_veto_full_ransom(insurance, chain, kidnapper, friends, password):
+def test_veto_full_ransom(committed_insurance, chain, kidnapper, friends, password):
     ransom = Wei("10 ether")
     initial_friends = friends.balance()
-    password_hash = insurance.generateHash(password, {'from': kidnapper})
-    insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
+    committed_insurance.initiateRansomWithdraw(password, ransom, {'from': kidnapper})
     chain.sleep(60 * 60 * 24 * 2)  # 2 days
-    insurance.vetoWithdraw({'from': friends, 'value': ransom * 2})
-    assert insurance.balance() == 0
+    committed_insurance.vetoWithdraw({'from': friends, 'value': ransom * 2})
+    assert committed_insurance.balance() == 0
     assert initial_friends - 2 * ransom == friends.balance()
     chain.sleep(60 * 60 * 24 * 2)  # 2 days
     with reverts("Kidnapper: Was vetoed"):
-        insurance.withdrawRansom({'from': kidnapper})
+        committed_insurance.withdrawRansom({'from': kidnapper})
 
 
-def test_fuck_you(insurance, kidnapper, friends, password):
+def test_fuck_you(committed_insurance, kidnapper, friends, password):
     ransom = Wei("10 ether")
-    password_hash = insurance.generateHash(password, {'from': kidnapper})
-    insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
-    tx = insurance.vetoWithdraw({'from': friends, 'value': ransom * 2})
+    committed_insurance.initiateRansomWithdraw(password, ransom, {'from': kidnapper})
+    tx = committed_insurance.vetoWithdraw({'from': friends, 'value': ransom * 2})
     assert "FuckYou" in tx.events
 
 
-def test_veto_refund(insurance, kidnapper, friends, password):
+def test_veto_refund(committed_insurance, kidnapper, friends, password):
     ransom = Wei("5 ether")
-    expected_refund = insurance.balance() - ransom
+    expected_refund = committed_insurance.balance() - ransom
     initial_friends = friends.balance()
-    password_hash = insurance.generateHash(password, {'from': kidnapper})
-    insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
-    insurance.vetoWithdraw({'from': friends, 'value': ransom * 2})
+    committed_insurance.initiateRansomWithdraw(password, ransom, {'from': kidnapper})
+    committed_insurance.vetoWithdraw({'from': friends, 'value': ransom * 2})
     assert initial_friends - 2 * ransom + expected_refund == friends.balance()
 
 
-def test_insufficient_veto(insurance, kidnapper, friends, password):
+def test_insufficient_veto(committed_insurance, kidnapper, friends, password):
     ransom = Wei("5 ether")
-    password_hash = insurance.generateHash(password, {'from': kidnapper})
-    insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
+    committed_insurance.initiateRansomWithdraw(password, ransom, {'from': kidnapper})
     with reverts("Kindapper: Insufficient veto amount"):
-        insurance.vetoWithdraw({'from': friends, 'value': ransom})
+        committed_insurance.vetoWithdraw({'from': friends, 'value': ransom})
 
 
-def test_veto_before_kidnap(insurance, friends):
+def test_veto_before_kidnap(committed_insurance, friends):
     with reverts("Kidnapper: No active ransom"):
-        insurance.vetoWithdraw({'from': friends, 'value': "10 ether"})
+        committed_insurance.vetoWithdraw({'from': friends, 'value': "10 ether"})

--- a/tests/test_kidnap.py
+++ b/tests/test_kidnap.py
@@ -1,0 +1,114 @@
+from brownie import Wei, reverts
+
+
+def test_rescued(insurance, chain, kidnapper, password):
+    ransom = Wei("10 ether")
+    initial_kidnapper = kidnapper.balance()
+    password_hash = insurance.generateHash(password, {'from': kidnapper})
+    insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
+    chain.sleep(60 * 60 * 24 * 3 + 1000)  # 3 days and 1000 seconds
+    insurance.withdrawRansom({'from': kidnapper})
+    assert initial_kidnapper + ransom == kidnapper.balance()
+
+
+def test_abducted_rescued(insurance, chain, kidnapper, password):
+    ransom = Wei("10 ether")
+    password_hash = insurance.generateHash(password, {'from': kidnapper})
+    tx = insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
+    assert "Abducted" in tx.events
+    assert tx.events["Abducted"].values() == [kidnapper, ransom]
+
+    chain.sleep(60 * 60 * 24 * 3 + 1000)  # 3 days and 1000 seconds
+    tx = insurance.withdrawRansom({'from': kidnapper})
+    assert "Rescued" in tx.events
+
+
+def test_ransom_too_high(insurance, kidnapper, password):
+    ransom = Wei("100 ether")
+    password_hash = insurance.generateHash(password, {'from': kidnapper})
+    with reverts("Kidnapper: Not enough ransom available"):
+        insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
+
+
+def test_friends_increase_deposit(insurance, kidnapper, password, friends):
+    ransom = Wei("100 ether")
+    friends.transfer(insurance, "90 ether")
+    password_hash = insurance.generateHash(password, {'from': kidnapper})
+    insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
+    assert insurance.ransomAmount() == ransom
+
+
+def test_wrong_password(insurance, kidnapper):
+    password_hash = insurance.generateHash("wrong password", {'from': kidnapper})
+    with reverts("Kidnapper: Invalid password or sender"):
+        insurance.initiateRansomWithdraw(password_hash, "1 ether", {'from': kidnapper})
+
+
+def test_frontrunning_protection(insurance, kidnapper, frontrunner, password):
+    password_hash = insurance.generateHash(password, {'from': kidnapper})
+    with reverts("Kidnapper: Invalid password or sender"):
+        insurance.initiateRansomWithdraw(password_hash, "1 ether", {'from': frontrunner})
+
+
+def test_no_early_withdraw(insurance, kidnapper, password):
+    password_hash = insurance.generateHash(password, {'from': kidnapper})
+    insurance.initiateRansomWithdraw(password_hash, "10 ether", {'from': kidnapper})
+    with reverts("Kidnapper: Cannot withdraw yet"):
+        insurance.withdrawRansom({'from': kidnapper})
+
+
+def test_return_excess_funds(insurance, chain, kidnapper, friends, password):
+    friends.transfer(insurance, "90 ether")  # total 100 ether on insurance
+    ransom = Wei("50 ether")
+    initial_friends = friends.balance()
+    password_hash = insurance.generateHash(password, {'from': kidnapper})
+    insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
+    chain.sleep(60 * 60 * 24 * 3 + 1000)  # 3 days and 1000 seconds
+    insurance.withdrawRansom({'from': kidnapper})
+    # 50 eth to kidnapper and friends each
+    assert initial_friends + Wei("50 ether") == friends.balance()
+
+
+def test_veto_full_ransom(insurance, chain, kidnapper, friends, password):
+    ransom = Wei("10 ether")
+    initial_friends = friends.balance()
+    password_hash = insurance.generateHash(password, {'from': kidnapper})
+    insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
+    chain.sleep(60 * 60 * 24 * 2)  # 2 days
+    insurance.vetoWithdraw({'from': friends, 'value': ransom * 2})
+    assert insurance.balance() == 0
+    assert initial_friends - 2 * ransom == friends.balance()
+    chain.sleep(60 * 60 * 24 * 2)  # 2 days
+    with reverts("Kidnapper: Was vetoed"):
+        insurance.withdrawRansom({'from': kidnapper})
+
+
+def test_fuck_you(insurance, kidnapper, friends, password):
+    ransom = Wei("10 ether")
+    password_hash = insurance.generateHash(password, {'from': kidnapper})
+    insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
+    tx = insurance.vetoWithdraw({'from': friends, 'value': ransom * 2})
+    assert "FuckYou" in tx.events
+
+
+def test_veto_refund(insurance, kidnapper, friends, password):
+    ransom = Wei("5 ether")
+    expected_refund = insurance.balance() - ransom
+    initial_friends = friends.balance()
+    password_hash = insurance.generateHash(password, {'from': kidnapper})
+    insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
+    insurance.vetoWithdraw({'from': friends, 'value': ransom * 2})
+    assert initial_friends - 2 * ransom + expected_refund == friends.balance()
+
+
+def test_insufficient_veto(insurance, kidnapper, friends, password):
+    ransom = Wei("5 ether")
+    password_hash = insurance.generateHash(password, {'from': kidnapper})
+    insurance.initiateRansomWithdraw(password_hash, ransom, {'from': kidnapper})
+    with reverts("Kindapper: Insufficient veto amount"):
+        insurance.vetoWithdraw({'from': friends, 'value': ransom})
+
+
+def test_veto_before_kidnap(insurance, friends):
+    with reverts("Kidnapper: No active ransom"):
+        insurance.vetoWithdraw({'from': friends, 'value': "10 ether"})


### PR DESCRIPTION
Check the updated readme for my changes.

Instead of needing access to an account, in this version the insuree just needs a password.
With this password it is possible to initiate the withdraw process and later claim the funds. 
Everything should be front-run proof.

Also added a test suite that you can run with brownie if you want.

![image](https://user-images.githubusercontent.com/18177452/105636152-30e6b300-5e67-11eb-9d3c-1d5ded4ce9b3.png)


Cool project ^^
